### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/ImageManager.java
+++ b/app/src/main/java/com/einmalfel/podlisten/ImageManager.java
@@ -28,6 +28,7 @@ public class ImageManager {
   private static final String TAG = "IMG";
   private static final int WIDTH_DP = 70;
   private static final int PAGES_TO_CACHE = 10;
+  public static final String FAILED_TO_CLOSE_STREAM = "Failed to close stream";
   private final int widthPx;
   private static ImageManager instance;
 
@@ -131,14 +132,14 @@ public class ImageManager {
         try {
           lock.release();
         } catch (IOException exception) {
-          Log.wtf(TAG, "Failed to close stream", exception);
+          Log.wtf(TAG, FAILED_TO_CLOSE_STREAM, exception);
         }
       }
       if (stream != null) {
         try {
           stream.close();
         } catch (IOException exception) {
-          Log.wtf(TAG, "Failed to close stream", exception);
+          Log.wtf(TAG, FAILED_TO_CLOSE_STREAM, exception);
         }
       }
     }
@@ -183,14 +184,14 @@ public class ImageManager {
         try {
           lock.release();
         } catch (IOException exception) {
-          Log.wtf(TAG, "Failed to close stream", exception);
+          Log.wtf(TAG, FAILED_TO_CLOSE_STREAM, exception);
         }
       }
       if (stream != null) {
         try {
           stream.close();
         } catch (IOException exception) {
-          Log.wtf(TAG, "Failed to close stream", exception);
+          Log.wtf(TAG, FAILED_TO_CLOSE_STREAM, exception);
         }
       }
     }

--- a/app/src/main/java/com/einmalfel/podlisten/Provider.java
+++ b/app/src/main/java/com/einmalfel/podlisten/Provider.java
@@ -76,6 +76,9 @@ public class Provider extends ContentProvider {
     }
   }
 
+  public static final String WRONG_QUERY_URI_MESSAGE = "Wrong query uri %s, code: %d";
+  public static final String TEXT = " TEXT,";
+  public static final String INTEGER = " INTEGER,";
   public static final String T_EPISODE = "episode";
   public static final String T_PODCAST = "podcast";
   public static final String T_E_JOIN_P = "episode_join_podcast";
@@ -149,7 +152,7 @@ public class Provider extends ContentProvider {
   public int delete(Uri uri, String selection, String[] selectionArgs) {
     int code = matcher.match(uri);
     if (code == -1) {
-      Log.e(TAG, "Wrong query uri " + uri + ". Code " + code);
+      Log.e(TAG, String.format(WRONG_QUERY_URI_MESSAGE, uri, code));
       return 0;
     }
     if (code >= TABLES.length) {
@@ -183,7 +186,7 @@ public class Provider extends ContentProvider {
   public Uri insert(Uri uri, ContentValues values) {
     int code = matcher.match(uri);
     if (code < 0 || code >= TABLES.length) {
-      Log.e(TAG, "Wrong insert uri " + uri + ". Code " + code);
+      Log.e(TAG, String.format("Wrong insert uri %s, code: %d", uri, code));
       return null;
     }
     if (code == TABLES.length - 1) {
@@ -229,7 +232,7 @@ public class Provider extends ContentProvider {
                       String[] selectionArgs, String sortOrder) {
     int code = matcher.match(uri);
     if (code == -1) {
-      Log.e(TAG, "Wrong query uri " + uri + ". Code " + code);
+      Log.e(TAG, String.format(WRONG_QUERY_URI_MESSAGE, uri, code));
       return null;
     }
     if (code >= TABLES.length) {
@@ -270,7 +273,7 @@ public class Provider extends ContentProvider {
                     String[] selectionArgs) {
     int code = matcher.match(uri);
     if (code == -1) {
-      Log.e(TAG, "Wrong query uri " + uri + ". Code " + code);
+      Log.e(TAG, String.format(WRONG_QUERY_URI_MESSAGE, uri, code));
       return 0;
     }
     if (code >= TABLES.length) {
@@ -300,36 +303,36 @@ public class Provider extends ContentProvider {
     public void onCreate(SQLiteDatabase db) {
       db.execSQL("CREATE TABLE " + T_PODCAST + " (" +
           K_ID + " INTEGER PRIMARY KEY," +
-          K_PNAME + " TEXT," +
-          K_PDESCR + " TEXT," +
-          K_PSDESCR + " TEXT," +
-          K_PSTATE + " INTEGER," +
-          K_PRMODE + " INTEGER," +
-          K_PATSTAMP + " INTEGER," +
-          K_PURL + " TEXT," +
-          K_PFURL + " TEXT," +
-          K_PERROR + " TEXT," +
+          K_PNAME + TEXT +
+          K_PDESCR + TEXT +
+          K_PSDESCR + TEXT +
+          K_PSTATE + INTEGER +
+          K_PRMODE + INTEGER +
+          K_PATSTAMP + INTEGER +
+          K_PURL + TEXT +
+          K_PFURL + TEXT +
+          K_PERROR + TEXT +
           K_PTSTAMP + " INTEGER" +
           ')');
       db.execSQL("CREATE TABLE " + T_EPISODE + " (" +
           K_ID + " INTEGER PRIMARY KEY," +
-          K_ENAME + " TEXT," +
-          K_EDESCR + " TEXT," +
-          K_ESDESCR + " TEXT," +
-          K_EURL + " TEXT," +
-          K_EAURL + " TEXT," +
-          K_EERROR + " TEXT," +
-          K_EDATE + " INTEGER," +
-          K_EDFIN + " INTEGER," +
-          K_EDATT + " INTEGER," +
-          K_EDID + " INTEGER," +
-          K_ESTATE + " INTEGER," +
-          K_ETSTAMP + " INTEGER," +
-          K_EPLAYED + " INTEGER," +
-          K_ELENGTH + " INTEGER," +
-          K_ESIZE + " INTEGER," +
-          K_EDTSTAMP + " INTEGER," +
-          K_EPID + " INTEGER," +
+          K_ENAME + TEXT +
+          K_EDESCR + TEXT +
+          K_ESDESCR + TEXT +
+          K_EURL + TEXT +
+          K_EAURL + TEXT +
+          K_EERROR + TEXT +
+          K_EDATE + INTEGER +
+          K_EDFIN + INTEGER +
+          K_EDATT + INTEGER +
+          K_EDID + INTEGER +
+          K_ESTATE + INTEGER +
+          K_ETSTAMP + INTEGER +
+          K_EPLAYED + INTEGER +
+          K_ELENGTH + INTEGER +
+          K_ESIZE + INTEGER +
+          K_EDTSTAMP + INTEGER +
+          K_EPID + INTEGER +
           "FOREIGN KEY(" + K_EPID + ") REFERENCES " + T_PODCAST + '(' + K_ID + ')' +
           ')');
     }

--- a/app/src/main/java/com/einmalfel/podlisten/Storage.java
+++ b/app/src/main/java/com/einmalfel/podlisten/Storage.java
@@ -19,6 +19,7 @@ public class Storage {
   private static final String TAG = "STR";
   private static final String UNKNOWN_STATE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ?
       Environment.MEDIA_UNKNOWN : "unknown";
+  public static final String ANDROID_DATA_COM_EINMALFEL_PODLISTEN_FILES = "Android/data/com.einmalfel.podlisten/files";
   private final File appFilesDir; // /*/Android/data/com.einmalfel.podlisten/files
 
   /**@return Ordered and deduplicated list of writable storages. Order: primary first, then dirs
@@ -28,7 +29,7 @@ public class Storage {
     List<Storage> result = new LinkedList<>();
     Set<File> dirs = new LinkedHashSet<>();
     dirs.add(new File(Environment.getExternalStorageDirectory(),
-                      "Android/data/com.einmalfel.podlisten/files"));
+            ANDROID_DATA_COM_EINMALFEL_PODLISTEN_FILES));
     dirs.addAll(Arrays.asList(ContextCompat.getExternalFilesDirs(PodListenApp.getContext(), null)));
     for (String env : new String[]{"EXTERNAL_STORAGE", "SECONDARY_STORAGE",
                                    "EXTERNAL_SDCARD_STORAGE", "SECOND_VOLUME_STORAGE",
@@ -39,7 +40,7 @@ public class Storage {
           File storageDir = new File(path);
           // filter legacy out. Download to thais dir fails on CyanogenMod because of perm. problems
           if (!path.startsWith("/storage/emulated/legacy") && storageDir.isDirectory()) {
-            File filesDir = new File(storageDir, "Android/data/com.einmalfel.podlisten/files");
+            File filesDir = new File(storageDir, ANDROID_DATA_COM_EINMALFEL_PODLISTEN_FILES);
             if (dirs.add(filesDir)) {
               Log.i(TAG, "Found storage via environment variable: " + filesDir);
             }
@@ -108,7 +109,7 @@ public class Storage {
   public static Storage getPrimaryStorage() {
     try {
       return new Storage(new File(Environment.getExternalStorageDirectory(),
-                                  "Android/data/com.einmalfel.podlisten/files"));
+              ANDROID_DATA_COM_EINMALFEL_PODLISTEN_FILES));
     } catch (IOException exception) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
         throw new AssertionError("Cant convert primary storage to canonical form", exception);

--- a/app/src/main/java/com/einmalfel/podlisten/SyncWorker.java
+++ b/app/src/main/java/com/einmalfel/podlisten/SyncWorker.java
@@ -40,6 +40,7 @@ class SyncWorker implements Runnable {
   private static final int MAX_EPISODES_TO_PARSE = 1000;
   private static final Pattern AUDIO_PATTERN = Pattern.compile("\\Aaudio/.*\\Z");
   private static final Date PODCAST_EPOCH;
+  public static final String BR = "<br/>";
 
   // there where no podcasts before year 2000. Earlier pubDate's will be replaced with current time
   static {
@@ -429,13 +430,13 @@ class SyncWorker implements Runnable {
     text = listPattern.matcher(text).replaceAll("\u2022");
 
     // replace \n and </li> with line breaks. Need all LF tokens to be <br> to reduce them later
-    text = brPattern.matcher(text).replaceAll("<br/>");
+    text = brPattern.matcher(text).replaceAll(BR);
 
     // throw out tags not supported by spanned text
     text = Html.toHtml(Html.fromHtml(text));
 
     // toHtml may add some excess <p> tags
-    text = paragraphPattern.matcher(text).replaceAll("<br/>");
+    text = paragraphPattern.matcher(text).replaceAll(BR);
 
     // There is a problem: toHtml returns escaped html, thus making resulting string much longer.
     // The only solution I found is to make use of unbescape library.
@@ -446,7 +447,7 @@ class SyncWorker implements Runnable {
     text = trimStartPattern.matcher(text).replaceAll("");
 
     // reduce repeated <br>'s
-    text = brRepeatPattern.matcher(text).replaceAll("<br/>");
+    text = brRepeatPattern.matcher(text).replaceAll(BR);
 
     // using autoLinks="all" for TextView will highlight links in flat text, but will break <href>'s
     text = EMAIL_ADDRESS.matcher(text).replaceAll("$1<a href=\"mailto:$2\">$2</a>$3");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava