### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end with a default clause

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/DownloadReceiver.java
+++ b/app/src/main/java/com/einmalfel/podlisten/DownloadReceiver.java
@@ -297,6 +297,9 @@ public class DownloadReceiver extends BroadcastReceiver {
                                 intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0L));
           updateDownloadQueue(context, false);
           break;
+        default:
+          Log.e(TAG, "Unexpected intent received: " + intent);
+          break;
       }
     }
   }

--- a/app/src/main/java/com/einmalfel/podlisten/MainActivity.java
+++ b/app/src/main/java/com/einmalfel/podlisten/MainActivity.java
@@ -225,6 +225,9 @@ public class MainActivity extends FragmentActivity implements PlayerService.Play
       case SUBSCRIPTIONS:
         lerpFAB(FabAction.ADD, FabAction.ADD, 0);
         break;
+      default:
+        Log.e(TAG, "Unexpected fragment received: " + fragment);
+        break;
     }
   }
 
@@ -242,6 +245,9 @@ public class MainActivity extends FragmentActivity implements PlayerService.Play
           break;
         case CLEAR:
           fab.setImageResource(R.mipmap.ic_clear_all_black_24dp);
+          break;
+        default:
+          Log.e(TAG, "Unexpected action received: " + action);
           break;
       }
       currentFabAction = action;
@@ -415,6 +421,9 @@ public class MainActivity extends FragmentActivity implements PlayerService.Play
             Log.w(TAG, "Playlist fragment doesn't exist yet, skipping reload");
           }
           snackbarController.showSnackbar(newMode.toString(), Snackbar.LENGTH_SHORT, null, null);
+          break;
+        default:
+          Log.e(TAG, "Unexpected currentFabAction received: " + currentFabAction);
           break;
       }
     } else if (v == playButton) {

--- a/app/src/main/java/com/einmalfel/podlisten/PlayerService.java
+++ b/app/src/main/java/com/einmalfel/podlisten/PlayerService.java
@@ -130,6 +130,9 @@ public class PlayerService extends DebuggableService implements MediaPlayer.OnSe
                 onCompletion(player);
               }
               break;
+            default:
+              Log.e(TAG, "Unexpected ct received: " + ct);
+              break;
           }
         }
       }
@@ -684,6 +687,9 @@ public class PlayerService extends DebuggableService implements MediaPlayer.OnSe
         break;
       case PAUSED:
         resume();
+        break;
+      default:
+        Log.e(TAG, "Unexpected state received: " + state);
         break;
     }
   }

--- a/app/src/main/java/com/einmalfel/podlisten/Preferences.java
+++ b/app/src/main/java/com/einmalfel/podlisten/Preferences.java
@@ -417,6 +417,9 @@ public class Preferences implements SharedPreferences.OnSharedPreferenceChangeLi
           }
         }
         break;
+      default:
+        Log.e(TAG, "Unexpected key received: " + key);
+        break;
     }
   }
 

--- a/app/src/main/java/com/einmalfel/podlisten/PreferencesActivity.java
+++ b/app/src/main/java/com/einmalfel/podlisten/PreferencesActivity.java
@@ -103,6 +103,9 @@ public class PreferencesActivity extends AppCompatActivity {
           }
         }
         break;
+      default:
+        Log.e(TAG, "Unexpected intent received: " + intent);
+        break;
     }
   }
 

--- a/app/src/main/java/com/einmalfel/podlisten/SubscribeDialog.java
+++ b/app/src/main/java/com/einmalfel/podlisten/SubscribeDialog.java
@@ -72,6 +72,9 @@ public class SubscribeDialog extends AppCompatDialogFragment implements View.OnC
         case SEARCH_REQUEST_ID:
           urlText.setText(data.getStringExtra(SearchActivity.RSS_URL_EXTRA));
           break;
+        default:
+          Log.e(TAG, "Unexpected requestCode received: " + requestCode);
+          break;
       }
     }
   }

--- a/app/src/main/java/com/einmalfel/podlisten/WidgetHelper.java
+++ b/app/src/main/java/com/einmalfel/podlisten/WidgetHelper.java
@@ -176,6 +176,9 @@ public class WidgetHelper implements PlayerService.PlayerStateListener {
       case STOP:
         connection.service.stop();
         break;
+      default:
+        Log.e(TAG, "Unexpected action received: " + action);
+        break;
     }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - switch statements should end with a default clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava