### PR TITLE
squid:S2142 - InterruptedException should not be ignored

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/EpisodesSyncAdapter.java
+++ b/app/src/main/java/com/einmalfel/podlisten/EpisodesSyncAdapter.java
@@ -89,12 +89,15 @@ public class EpisodesSyncAdapter extends AbstractThreadedSyncAdapter {
     try {
       workersDone = executorService.awaitTermination(SYNC_TIMEOUT, TimeUnit.SECONDS);
     } catch (InterruptedException interrupt) {
+      Thread.currentThread().interrupt();
       syncState.error(getContext().getString(R.string.sync_interrupted_by_system));
       // sync cancelled. Discard queue, try to interrupt workers and wait for them again
       executorService.shutdownNow();
       try {
         workersDone = executorService.awaitTermination(SYNC_TIMEOUT, TimeUnit.SECONDS);
-      } catch (InterruptedException ignored) {}
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+      }
     }
     if (!workersDone) {
       Log.e(TAG, "Some of workers hanged during sync");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2142 - InterruptedException should not be ignored.
This pull request removes technical debt of 45 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2142
Please let me know if you have any questions.
George Kankava