### PR TITLE
squid:S2696 - Instance methods should not write to 'static' fields

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/PodListenApp.java
+++ b/app/src/main/java/com/einmalfel/podlisten/PodListenApp.java
@@ -27,7 +27,7 @@ import org.acra.annotation.ReportsCrashes;
     resDialogOkToast = R.string.crash_dialog_ok_toast
 )
 public class PodListenApp extends DebuggableApp implements Application.ActivityLifecycleCallbacks {
-  private static PodListenApp instance;
+  private static volatile PodListenApp instance;
 
   public static PodListenApp getInstance() {
     return instance;

--- a/app/src/main/java/com/einmalfel/podlisten/Provider.java
+++ b/app/src/main/java/com/einmalfel/podlisten/Provider.java
@@ -134,7 +134,7 @@ public class Provider extends ContentProvider {
   private static final String[] TABLES = {T_EPISODE, T_PODCAST, T_E_JOIN_P};
   private static final UriMatcher matcher = new UriMatcher(UriMatcher.NO_MATCH);
   private static final String TAG = "PLP";
-  private static HelperV1 helper;
+  private static volatile HelperV1 helper;
   private ContentResolver resolver;
 
   public static Uri getUri(String table, Long id) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2696 - Instance methods should not write to 'static' fields.
This pull request removes technical debt of 40 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2696
Please let me know if you have any questions.
George Kankava