### PR TITLE
Reverse order of new episodes list to show latest first

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/NewEpisodesFragment.java
+++ b/app/src/main/java/com/einmalfel/podlisten/NewEpisodesFragment.java
@@ -66,7 +66,7 @@ public class NewEpisodesFragment extends DebuggableFragment implements LoaderMan
         EpisodeListAdapter.REQUIRED_DB_COLUMNS,
         Provider.K_ESTATE + " = " + Provider.ESTATE_NEW,
         null,
-        Provider.K_EDATE);
+        Provider.K_EDATE + " DESC");
   }
 
   @Override


### PR DESCRIPTION
Add descending to the orderby argument in CursorLoader.  Just a small change that makes new episodes show up at the top of the new podcast list.

Thanks for the awesome work!