### PR TITLE
Add headset button support - one line of code

### DIFF
--- a/app/src/main/java/com/einmalfel/podlisten/MediaButtonReceiver.java
+++ b/app/src/main/java/com/einmalfel/podlisten/MediaButtonReceiver.java
@@ -54,6 +54,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
     }
     Log.d(TAG, "Processing media button: " + ev);
     switch (ev.getKeyCode()) {
+      case KeyEvent.KEYCODE_HEADSETHOOK:
       case KeyEvent.KEYCODE_MEDIA_PAUSE: // play and pause events could mean play_pause
       case KeyEvent.KEYCODE_MEDIA_PLAY:
       case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:


### PR DESCRIPTION
I always use this feature - just pause and resume without taking the phone out of your pocket. 
Some earphones have this button on, this adds support for it. 
Other podcast apps support this option. It's one line of code, I don't think it will affect anything else. 

By the way, thanks so much for coding this great app, other podcast apps are getting too bloated these days. 